### PR TITLE
added ancestor option and ancestor check

### DIFF
--- a/pathmap/__init__.py
+++ b/pathmap/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .pathmap import (
     clean_path,
+    _check_ancestors,
     _slash_pattern,
     _extract_match,
     _resolve_path,

--- a/pathmap/lcsmodule.c
+++ b/pathmap/lcsmodule.c
@@ -81,9 +81,7 @@ lcs(PyObject* self, PyObject* args)
     substr = (char *)malloc(longest+1 * sizeof(char));
     memset(substr, '\0', longest+1);
 
-    while (results[++i] != -1) {
-        strncpy(substr, &s1[results[i] - longest + 1], longest);
-    }
+    strncpy(substr, &s1[results[1] - longest + 1], longest);
 
     PyObject *ret = Py_BuildValue("s", substr, longest+1);
 

--- a/pathmap/pathmap.py
+++ b/pathmap/pathmap.py
@@ -23,8 +23,8 @@ def clean_path(path):
 
 def _check_ancestors(path, match, ancestors):
     anc = ancestors + 1
-    split_path = path.split('/')
-    split_match = match.split('/')
+    split_path = path.lower().split('/')
+    split_match = match.lower().split('/')
 
     if len(split_path) < anc or len(split_match) < anc:
         return False
@@ -63,8 +63,6 @@ def _extract_match(toc, index):
         start_index -= 1
     end_index = index
     while toc[end_index] != ',' and end_index < length - 1:
-        end_index += 1
-    if end_index == length - 1:
         end_index += 1
     return toc[start_index+1:end_index]
 

--- a/pathmap/pathmap.py
+++ b/pathmap/pathmap.py
@@ -21,6 +21,18 @@ def clean_path(path):
     )
     return path
 
+def _check_ancestors(path, match, ancestors):
+    anc = ancestors + 1
+    split_path = path.split('/')
+    split_match = match.split('/')
+
+    if len(split_path) < anc or len(split_match) < anc:
+        return False
+
+    path_ancestors  = split_path[len(split_path) - anc:]
+    match_ancestors = split_match[len(split_match) - anc:]
+
+    return path_ancestors == match_ancestors
 
 def _slash_pattern(pattern):
     """
@@ -109,7 +121,13 @@ def _resolve_path_if_long(toc, path, ancestors=None):
         # Find the index that matches the loc
         index = toc.lower().find(loc.lower())
         # Extract string from location
-        match = _extract_match(toc, index)
+        # and remove extra ',' characters if present
+        match = _extract_match(toc, index).replace(',','')
+
+        # If ancestors are declared check if they are valid
+        if ancestors:
+            if not _check_ancestors(path, match, ancestors):
+                return None, None
 
         # We expect the longest common substring
         # to have a match in the end of the string
@@ -162,8 +180,8 @@ def resolve_by_method(toc):
     # keep a cache of known changes
     resolvers = []
 
-    def _resolve(path):
-        (new_path, resolve) = _resolve_path(toc, path, resolvers)
+    def _resolve(path, ancestors=None):
+        (new_path, resolve) = _resolve_path(toc, path, resolvers, ancestors)
         if new_path:
             # add known resolve
             if resolve:

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -16,6 +16,7 @@ from pathmap import (
     _extract_match,
     _resolve_path,
     _resolve_path_if_long,
+    _check_ancestors,
     resolve_paths,
     resolve_by_method
 )
@@ -111,3 +112,36 @@ def test_resolve_by_method():
     first = set(map(resolver, before))
     second = set(after)
     assert first == second
+
+
+def test_check_ancestors():
+    ancestors = 1
+    path = 'one/two/three'
+    match = 'four/two/three'
+
+    assert _check_ancestors(path, match, ancestors) == True
+    match = 'four/five/three'
+    assert _check_ancestors(path, match, ancestors) == False
+
+def test_resolve_paths_with_ancestors():
+    toc      = ',x/y/z,'
+    
+    # default, no ancestors ============================
+    paths    = ['z','R/z', 'R/y/z', 'x/y/z', 'w/x/y/z']
+    expected = ['x/y/z','x/y/z','x/y/z','x/y/z','x/y/z']
+    resolved = list(resolve_paths(toc, paths))
+
+    assert set(resolved) == set(expected)
+    # one ancestors ====================================
+    paths    = ['z', 'R/z', 'R/y/z', 'x/y/z', 'w/x/y/z']
+    expected = [None, None,'x/y/z','x/y/z','x/y/z']
+    resolved = list(resolve_paths(toc, paths, 1))
+
+    assert set(resolved) == set(expected)
+    
+     # two ancestors ====================================
+    paths    = ['z', 'R/z', 'R/y/z', 'x/y/z', 'w/x/y/z']
+    expected = [None, None, None,    'x/y/z',   'x/y/z']
+    resolved = list(resolve_paths(toc, paths, 2))
+    
+    assert set(resolved) == set(expected)

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -66,6 +66,7 @@ def test_slash_pattern():
 
 
 def test_extract_match():
+    toc = ',src/components/login.js,'
     index = toc.find('components')
     extracted = _extract_match(toc, index)
     assert extracted == 'src/components/login.js'
@@ -145,3 +146,12 @@ def test_resolve_paths_with_ancestors():
     resolved = list(resolve_paths(toc, paths, 2))
     
     assert set(resolved) == set(expected)
+
+def test_case_sensitive_ancestors():
+    toc = ',src/HeapDump/GCHeapDump.cs,'
+    path = 'C:/projects/perfview/src/heapDump/GCHeapDump.cs'
+    (path, pattern) = _resolve_path_if_long(toc, path, 1)
+
+    assert path == 'src/HeapDump/GCHeapDump.cs'
+
+


### PR DESCRIPTION
Ancestor check and tests added. Since the operation is relatively simple it's implemented in python. 
I doubt having this check in the lcs function in c will speed things up and it would also break the seperation of concern within the lcs function. Another idea is to check ancestors in C when the lcs function returns. If this method seems to be slowing the process down a lot I'm open for looking into that.