### PR TITLE
Invalid pattern of replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ Unity
 
 *.out
 *.out.*
+
+*.gcda
+*.gcno

--- a/pathmap/pathmap.py
+++ b/pathmap/pathmap.py
@@ -145,11 +145,18 @@ def _resolve_path_if_long(toc, path, ancestors=None):
             return None, None
 
         # Remove pattern
-        rm_pattern = path.replace(loc, '')
+        m_index = match.lower().find(loc.lower())
+        match_longest = match[m_index:] 
+
+        if match_longest != loc and match_longest.lower() == loc.lower():
+            rm_pattern = '/'.join(path.split('/')[:-1])
+            add_pattern = '/'.join(match.split('/')[:-1])
+        else:
+            rm_pattern = path.replace(loc, '')
+            add_pattern = match.replace(loc, '')
         if rm_pattern:
             rm_pattern = _slash_pattern(rm_pattern)
         # Add pattern
-        add_pattern = match.replace(loc, '')
         if add_pattern:
             add_pattern = _slash_pattern(add_pattern)
         return match, (rm_pattern, add_pattern)

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -160,3 +160,11 @@ def test_path_should_not_resolve():
     (path, pattern) = _resolve_path(toc, path, resolvers)
     assert path is None
     assert pattern is None
+
+def test_path_should_not_resolve_case_insensative():
+    resolvers = []
+    toc = ',a/b/C,'
+    path = 'System/a/B/c'
+    (path, pattern) = _resolve_path(toc, path, resolvers)
+    assert path == 'a/b/C'
+    assert pattern == ('System/a/B/', 'a/b/')

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -160,3 +160,12 @@ def test_path_should_not_resolve():
     (path, pattern) = _resolve_path(toc, path, resolvers)
     assert path is None
     assert pattern is None
+
+
+def test_path_should_not_resolve_case_insensative():
+    resolvers = []
+    toc = ',a/b/C,'
+    path = 'a/B/c'
+    (path, pattern) = _resolve_path(toc, path, resolvers)
+    assert path == 'a/b/C'
+    assert pattern == ('a/B/', 'a/b/')


### PR DESCRIPTION
```python
    def test_path_should_not_resolve_case_insensative():
        resolvers = []
        toc = ',a/b/C,'
        path = 'a/B/c'
        (path, pattern) = _resolve_path(toc, path, resolvers)
        assert path == 'a/b/C'
>       assert pattern == ('a/B/', 'a/b/')
E       assert ('', 'a/b/C/') == ('a/B/', 'a/b/')
```