### PR TITLE
Short long paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,75 @@ Pathmap
 
 [![codecov](https://codecov.io/gh/codecov/pathmap/branch/master/graph/badge.svg)](https://codecov.io/gh/codecov/pathmap)
 
+Pathmap is a library for resolving paths. Example
+
+```
+>>> from pathmap import resolve_paths
+>>> toc = ',a/b/c,'
+>>> paths = ['b/c']
+>>> list(resolve_paths(toc, paths))
+
+['a/b/c']
+
+```
+
+### Case sensitivity
+
+Pathmap searches for paths using lower case keys only but it stores the original value 
+of each path added to the tree. This way we can search for two identical paths with
+different casing
+
+```
+>>> from pathmap import resolve_paths
+>>> toc = ',a/b/C,A/B/c,'
+>>> paths = ['A/b/C','a/B/c']
+>>> list(resolve_paths(toc, paths))
+
+['a/b/C', 'A/B/c']
+
+```
+
+### Resolving shorter/longer paths
+
+When resolving paths it may happen that we get a partial path. For example searching for the path "two/three.py" in a tree that contains the path "dist/one/two/three.py".
+Pathmap will continue searhing for a possible match until it hits the end of the current sequence but only if there is a single possible result.
+
+For example if we add to our example 
+
+```
+
+toc = '''
+dist/one/two/three.py
+dist/another/two/three.py
+'''
+
+```
+
+With this toc we would construct a tree that looks something like this
+
+```
+    three.py
+        |
+       two
+    |       |
+   one    another
+    |       |
+   dist   dist
+```
+
+Now when we hit the branch containing the key "two" we have two possible options, either
+we resolve the path to "dist/one/two/three.py" or "dist/another/two/three.py". 
+In this case pathmap will not resolve the path and simply return None.
+
+### Local development
+
+Dependencies are listed in the requirements_dev.txt file
+
+	pip install -r requirements_dev.txt
+	
+### Testing
+
+pytest is used for testing. Run tests with
+
+	py.test
+

--- a/pathmap/tree.py
+++ b/pathmap/tree.py
@@ -21,16 +21,6 @@ class Tree:
 
         E.g.:
             ['a','b','c'] => { 'c' : { 'b' : { 'a' : {} } } }
-
-        extra data:
-
-            _end_ - Marks the end of the list
-            E.g.:
-                ['a','b'] => { 'b' : { 'a' : {}, '_end_': True}, '_end_': False}
-
-            _orig_ - The original value of the key/list item
-            E.g.:
-                ['A'] => { 'a' : {}, '_orig_': 'A', '_end_': True}
         """
         d = {}
         for i in range(0, len(lis)):
@@ -129,7 +119,7 @@ class Tree:
 
         return path_hit
 
-    def _update(self, d, u):
+    def update(self, d, u):
         """
         Update a dictionary
         :dict: d - Dictionary being updated
@@ -137,7 +127,7 @@ class Tree:
         """
         for k, v in u.items():
             if isinstance(v, collections.Mapping):
-                r = self._update(d.get(k, {}), v)
+                r = self.update(d.get(k, {}), v)
                 d[k] = r
             else:
                 if k == self._END and d.get(k) is True:
@@ -165,7 +155,7 @@ class Tree:
             self.instance.update(u)
         else:
             u = self._list_to_nested_dict(path_split)
-            self.instance = self._update(self.instance, u)
+            self.instance = self.update(self.instance, u)
 
     def construct_tree(self, toc):
         """

--- a/pathmap/tree.py
+++ b/pathmap/tree.py
@@ -55,6 +55,23 @@ class Tree:
 
         return possibilities[index]
 
+    def _drill(self, d, results):
+        """
+        Drill down a branch of a tree.
+        Collects results until a ._END is reached.
+
+        :returns - A list containing a possible path or None
+        """
+        if not d or d.get(self._ORIG) and len(d.get(self._ORIG)) > 1:
+            return None
+
+        root = d.get(list(d.keys())[0])
+
+        if root.get(self._END):
+            return root.get(self._ORIG)
+        else:
+            return self._drill(root, results)
+
     def _recursive_lookup(self, d, lis, results, i=0, end=False):
         """
         Performs a lookup in tree recursively
@@ -83,8 +100,11 @@ class Tree:
                 root.get(self._END)
             )
         else:
-            if not end:
+            if not end and results:
                 results = []
+                next_path = self._drill(d, results)
+                if next_path:
+                    results.extend(next_path)
             return results
 
     def lookup(self, path):
@@ -92,7 +112,7 @@ class Tree:
         Lookup a path in the tree
 
         :str: path - The path to search for
-
+    
         :returns The closest matching path in the tree if present else None
         """
         path_hit = None

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -79,6 +79,8 @@ def test_resolve_paths():
     resolved_paths = resolve_paths(toc, before)
     first = set([r for r in resolved_paths])
     second = set(after)
+    print(first)
+    print(second)
     assert first == second
 
 
@@ -90,13 +92,13 @@ def test_resolve_by_method():
     assert first == second
 
 
-def test_resolve_path_when_to_short(self):
-    assert resolve_paths(',a/b/c,', ['b/c'], 0).next() == 'a/b/c'
-    assert resolve_paths(',a/b/c,', ['b/c'], 1).next() == 'a/b/c'
+def test_resolve_path_when_to_short():
+    assert next(resolve_paths(',a/b/c,', ['b/c'], 0 )) == 'a/b/c'
+    assert next(resolve_paths(',a/b/c,', ['b/c'], 1)) == 'a/b/c'
 
 
-def test_resolve_path_when_to_long(self):
-    assert resolve_paths(',a/b/c,', ['z/y/b/c'], 1).next() == 'a/b/c'
+def test_resolve_path_when_to_long():
+    assert next(resolve_paths(',a/b/c,', ['z/y/b/c'], 1)) == 'a/b/c'
 
 
 def test_check_ancestors():
@@ -119,13 +121,13 @@ def test_resolve_paths_with_ancestors():
 
     # default, no ancestors ============================
     paths = ['z', 'R/z', 'R/y/z', 'x/y/z', 'w/x/y/z']
-    expected = [None, None, None, 'x/y/z', 'x/y/z']
+    expected = ['x/y/z', 'x/y/z', 'x/y/z', 'x/y/z', 'x/y/z']
     resolved = list(resolve_paths(toc, paths))
     assert resolved == expected
 
     # one ancestors ====================================
     paths = ['z', 'R/z', 'R/y/z', 'x/y/z', 'w/x/y/z']
-    expected = [None, None, None, 'x/y/z', 'x/y/z']
+    expected = [None, None, 'x/y/z', 'x/y/z', 'x/y/z']
     resolved = list(resolve_paths(toc, paths, 1))
     assert set(resolved) == set(expected)
 

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -79,8 +79,6 @@ def test_resolve_paths():
     resolved_paths = resolve_paths(toc, before)
     first = set([r for r in resolved_paths])
     second = set(after)
-    print(first)
-    print(second)
     assert first == second
 
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -11,6 +11,24 @@ class TestTree(object):
     def setup_method(self, method):
         self.tree.instance = {}
 
+    def test_list_to_nested_dict(self):
+        keys = ['a','b','c']
+        nested_dict = self.tree._list_to_nested_dict(keys)
+
+        leaf = nested_dict.get('c').get('b').get('a')
+
+        assert leaf
+        assert leaf.get(self.tree._END)
+        assert leaf.get(self.tree._ORIG) == ['a/b/c']
+
+    def test_get_best_match(self):
+        path = 'a/bB.py'
+        possibilities = ['c/bB.py', 'd/Bb.py']
+
+        match = self.tree._get_best_match(path, possibilities)
+
+        assert match == 'c/bB.py'
+
     def test_drill(self):
         """
         Test drilling a branch of tree
@@ -18,3 +36,48 @@ class TestTree(object):
         results = []
         nested = self.tree._list_to_nested_dict(['a','b','c'])
         assert self.tree._drill(nested, []) == ['a/b/c']
+
+    def test_recursive_lookup(self):
+        toc  = ',one/two/three.py,'
+        path = 'one/two/three.py'
+
+        self.tree.construct_tree(toc)
+
+        path_split = list(reversed(path.split('/')))
+        match = self.tree._recursive_lookup(self.tree.instance, path_split, [])
+
+        assert match == ['one/two/three.py']
+
+        path = 'four/five/three.py'
+        path_split = list(reversed(path.split('/')))
+        match = self.tree._recursive_lookup(self.tree.instance, path_split, [])
+
+        assert match == ['one/two/three.py']
+
+    def test_lookup(self):
+        toc  = ',one/two/three.py,'
+        path = 'two/one/three.py'
+        self.tree.construct_tree(toc)
+
+        assert self.tree.lookup(path) == 'one/two/three.py'
+
+    def test_update(self):
+        dict1 = self.tree._list_to_nested_dict(['a','b','c'])
+        dict2 = self.tree._list_to_nested_dict(['e','g','c'])
+
+        updated = self.tree.update(dict1, dict2)
+
+        assert updated.get('c').get('b').get('a')
+        assert updated.get('c').get('g').get('e')
+
+    def test_insert(self):
+        path = 'a/b/c.py'
+        self.tree.insert(path)
+
+        assert self.tree.instance.get('c.py').get('b').get('a')
+
+    def test_construct_tree(self):
+        toc = ',a/b/c,'
+
+        self.tree.construct_tree(toc)
+        assert self.tree.instance.get('c').get('b').get('a')

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -10,3 +10,11 @@ class TestTree(object):
 
     def setup_method(self, method):
         self.tree.instance = {}
+
+    def test_drill(self):
+        """
+        Test drilling a branch of tree
+        """
+        results = []
+        nested = self.tree._list_to_nested_dict(['a','b','c'])
+        assert self.tree._drill(nested, []) == ['a/b/c']


### PR DESCRIPTION
Updated tree to search for possible paths if they are too short/long.
The rule is that we only search for the next possible path if there is a single option available. 
The _drill function drills down a branch and collects the possible paths until hitting a ._END indicator. 
This way we collect the full path from the tree without having to match all parts of the path from the user. However as stated this only works if the tree does not contain more than one available option for the given path