### PR TITLE
fix ancestor case where closest length of path should be taken into a…

### DIFF
--- a/pathmap/pathmap.py
+++ b/pathmap/pathmap.py
@@ -44,7 +44,7 @@ def _resolve_path(tree, path, ancestors=None):
     """
     path = clean_path(path)
 
-    new_path = tree.lookup(path)
+    new_path = tree.lookup(path, ancestors)
 
     if new_path:
         if ancestors and not _check_ancestors(path, new_path, ancestors):

--- a/pathmap/pathmap.py
+++ b/pathmap/pathmap.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 
 from .tree import Tree
 

--- a/pathmap/tree.py
+++ b/pathmap/tree.py
@@ -62,7 +62,7 @@ class Tree:
         else:
             return self._drill(root, results)
 
-    def _recursive_lookup(self, d, lis, results, i=0, end=False):
+    def _recursive_lookup(self, d, lis, results, i=0, end=False, match=False):
         """
         Performs a lookup in tree recursively
 
@@ -71,6 +71,7 @@ class Tree:
         :list: results - Collected hit results
         :int: i - Index of lis
         :bool: end - Indicates if last lookup was the end of a sequence
+        :bool: match - Indicates if filename has any match in tree
 
         :returns a list of hit results if path is found in the tree
         """
@@ -81,23 +82,24 @@ class Tree:
 
         root = d.get(key)
         if root:
-            results = root.get(self._ORIG)
+            if root.get(self._END):
+                results = root.get(self._ORIG)
             return self._recursive_lookup(
                 root,
                 lis,
                 results,
                 i + 1,
-                root.get(self._END)
+                root.get(self._END),
+                True
             )
         else:
-            if not end and results:
-                results = []
+            if not end and match:
                 next_path = self._drill(d, results)
                 if next_path:
                     results.extend(next_path)
             return results
 
-    def lookup(self, path):
+    def lookup(self, path, ancestors=None):
         """
         Lookup a path in the tree
 
@@ -115,7 +117,12 @@ class Tree:
         if len(results) == 1:
             path_hit = results[0]
         else:
-            path_hit = self._get_best_match(path, list(reversed(results)))
+            if path.replace('.','').startswith('/') and ancestors:
+                path_lengths = list(map(lambda x: len(x), results))
+                closest_length = min(path_lengths, key=lambda x:abs(x-ancestors))
+                path_hit = next(x for x in results if len(x) == closest_length)
+            else:
+                path_hit = self._get_best_match(path, list(reversed(results)))
 
         return path_hit
 

--- a/pathmap/tree.py
+++ b/pathmap/tree.py
@@ -38,7 +38,12 @@ class Tree:
         """
 
         # Map out similarity of possible paths with the path being looked up
-        similarity = list(map(lambda x: SequenceMatcher(None, path, x).ratio(), possibilities))
+        similarity = list(
+            map(
+                lambda x: SequenceMatcher(None, path, x).ratio(),
+                possibilities
+            )
+        )
 
         # Get the index, value of the most similar path
         index, value = max(enumerate(similarity), key=operator.itemgetter(1))
@@ -55,7 +60,10 @@ class Tree:
         if not d or d.get(self._ORIG) and len(d.get(self._ORIG)) > 1:
             return None
 
-        root = d.get(list(d.keys())[0])
+        root_key = next(
+            x for x in d.keys() if x != self._ORIG and x != self._END
+        )
+        root = d.get(root_key)
 
         if root.get(self._END):
             return root.get(self._ORIG)
@@ -117,9 +125,11 @@ class Tree:
         if len(results) == 1:
             path_hit = results[0]
         else:
-            if path.replace('.','').startswith('/') and ancestors:
+            if path.replace('.', '').startswith('/') and ancestors:
                 path_lengths = list(map(lambda x: len(x), results))
-                closest_length = min(path_lengths, key=lambda x:abs(x-ancestors))
+                closest_length = min(
+                    path_lengths, key=lambda x: abs(x-ancestors)
+                )
                 path_hit = next(x for x in results if len(x) == closest_length)
             else:
                 path_hit = self._get_best_match(path, list(reversed(results)))

--- a/tests/test_pathmap.py
+++ b/tests/test_pathmap.py
@@ -178,3 +178,11 @@ def test_path_should_not_resolve_case_insensative():
 def test_ancestors_original_missing():
     results = list(resolve_paths(',shorter.h,', ['a/long/path/shorter.h'], 1))
     assert results == ['shorter.h']
+
+def test_ancestors_absolute_path():
+    toc = ',examples/ChurchNumerals.scala,tests/src/test/scala/at/logic/gapt/examples/ChurchNumerals.scala,'
+    paths = ['/home/travis/build/gapt/gapt/examples/ChurchNumerals.scala']
+    resolved = list(resolve_paths(toc, paths, 1))
+
+    assert resolved == ['examples/ChurchNumerals.scala']
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = py27, py33, py34, py36, flake8
+envlist = py27, py33, py34, py35, py36, flake8
+
+
+[flake8]
+exclude =
+    pathmap/__init__.py
 
 [testenv:flake8]
 basepython=python
@@ -13,7 +18,7 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}
+    py.test -v -s --basetemp={envtmpdir}
 
 
 ; If you want to make tox run the tests with the same versions, create a


### PR DESCRIPTION
If ancestors are provided and we don't find a direct match we should be taking the path that has the length closest to the ancestor count provided. The ancestors optional argument has been added to the lookup function of the tree. 