### PR TITLE
fix case where tree lookup resolves to path if one or more paths are …

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes

--- a/pathmap/tree.py
+++ b/pathmap/tree.py
@@ -57,12 +57,12 @@ class Tree:
 
         :returns - A list containing a possible path or None
         """
-        if not d or d.get(self._ORIG) and len(d.get(self._ORIG)) > 1:
+        root_keys = [x for x in d.keys() if x != self._ORIG and x != self._END]
+        if len(root_keys) > 1:
             return None
 
-        root_key = next(
-            x for x in d.keys() if x != self._ORIG and x != self._END
-        )
+        root_key = root_keys[0]
+
         root = d.get(root_key)
 
         if root.get(self._END):

--- a/pathmap/tree.py
+++ b/pathmap/tree.py
@@ -58,11 +58,11 @@ class Tree:
         :returns - A list containing a possible path or None
         """
         root_keys = [x for x in d.keys() if x != self._ORIG and x != self._END]
-        if len(root_keys) > 1:
+
+        if len(root_keys) > 1 or not root_keys:
             return None
 
         root_key = root_keys[0]
-
         root = d.get(root_key)
 
         if root.get(self._END):

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -37,6 +37,14 @@ class TestTree(object):
         nested = self.tree._list_to_nested_dict(['a','b','c'])
         assert self.tree._drill(nested, []) == ['a/b/c']
 
+    def test_drill_multiple_possible_paths(self):
+        toc = ',src/list.rs,benches/list.rs,'
+        self.tree.construct_tree(toc)
+
+        branch = self.tree.instance.get('list.rs')
+        results = []
+        assert self.tree._drill(branch, results) == None
+
     def test_recursive_lookup(self):
         toc  = ',one/two/three.py,'
         path = 'one/two/three.py'


### PR DESCRIPTION
This is a fix for the _drill function in tree.py. The current implementation does not correctly check if there are two or more options for resolving a path and so in some cases it fails and pathmap returns an incorrect path instead of returning None.